### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 一个基于 Model Context Protocol (MCP) 的 FFmpeg 辅助工具，提供视频处理功能。
 
+<a href="https://glama.ai/mcp/servers/@sworddut/mcp-ffmpeg-helper">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@sworddut/mcp-ffmpeg-helper/badge" alt="FFmpeg Helper MCP server" />
+</a>
+
 ## 功能概述
 
 MCP FFmpeg Helper 是一个轻量级服务器，它通过 MCP 协议将 FFmpeg 的强大功能暴露给 AI 助手。它支持以下视频处理操作：


### PR DESCRIPTION
This PR adds a badge for the [MCP FFmpeg Helper](https://glama.ai/mcp/servers/@sworddut/mcp-ffmpeg-helper) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@sworddut/mcp-ffmpeg-helper">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@sworddut/mcp-ffmpeg-helper/badge" alt="FFmpeg Helper MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.